### PR TITLE
Correct the windows shell command

### DIFF
--- a/Documentation/getting_started.md
+++ b/Documentation/getting_started.md
@@ -45,7 +45,7 @@ $ ln -s <repository-folder>/Documentation <folder-name>
 
 Windows:
 ```shell
-c:> mklink /d <repository-folder>\Documentation <folder-name>
+c:> mklink /d <folder-name> <repository-folder>\Documentation 
 ```
 
 Example:
@@ -57,7 +57,7 @@ $ ln -s /Projects/Dolittle/Runtime/Documentation Overview
 
 Windows:
 ```shell
-c:> mklink /d c:\Projects\Dolittle\Runtime\Documentation Overview
+c:> mklink /d Overview c:\Projects\Dolittle\Runtime\Documentation 
 ```
 
 Chances are you are contributing to the code of the repository and you can therefor leave it in place and maintain


### PR DESCRIPTION
mklink works the other way with the local directory-name first and the target last