### PR TITLE
Empty pages in navigation 

### DIFF
--- a/Source/Hugo/layouts/partials/link_item.html
+++ b/Source/Hugo/layouts/partials/link_item.html
@@ -2,6 +2,8 @@
 {{- $pages :=  (union .page.Pages .page.Sections) -}}
 {{- $isCurrentPage := eq (string $currentURL) .page.URL -}}
 {{- $isSection := eq .page.Kind "section" -}}
+{{- $isSectionWithChildren := and (eq .page.Kind "section") (gt (len $pages ) 0) }}
+{{- $hasContent := gt (len .page.Content) 0 }}
 
 {{- $pageSlug := .page.File -}}
 {{- if $isSection -}}
@@ -10,9 +12,13 @@
 
 {{- $isActivePath := in (string $currentURL) (lower $pageSlug) -}}
 <li class="{{ .page.Kind }} {{ if $isActivePath -}}active{{- end -}}">
-    {{- if and (eq .page.Kind "section") (gt (len $pages ) 0) -}}
+    {{- if $isSectionWithChildren -}}
     <i class="ti-angle-right expand"></i>
+    {{- if $hasContent -}}
     <a href="{{ .page.RelPermalink }}" class="{{- if $isCurrentPage -}}current_page{{- end }}">{{ .page.Title }}</a>
+    {{- else -}}
+    <span>{{ .page.Title}}</span>
+    {{- end -}}
     <ul>
         {{- range $pages.ByWeight -}}
         {{- partial "link_item.html" (dict "page" . "CurrentURL" $currentURL) -}}

--- a/Source/Hugo/layouts/partials/link_item.html
+++ b/Source/Hugo/layouts/partials/link_item.html
@@ -11,7 +11,9 @@
 {{- end -}}
 
 {{- $isActivePath := in (string $currentURL) (lower $pageSlug) -}}
-<li class="{{ .page.Kind }} {{ if $isActivePath -}}active{{- end -}}">
+{{- if and $isSection (not $isSectionWithChildren) (not $hasContent) -}}
+{{- else -}}
+<li class="{{ .page.Kind }} {{ if $isActivePath }}active{{ end }}">
     {{- if $isSectionWithChildren -}}
     <i class="ti-angle-right expand"></i>
     {{- if $hasContent -}}
@@ -28,3 +30,4 @@
     <a href="{{ .page.RelPermalink }}" class="{{- if $isCurrentPage -}}current_page{{- end }}">{{ .page.Title }}</a>
     {{- end -}}
 </li>
+{{- end -}}

--- a/Source/Hugo/static/css/dolittle.dot.css
+++ b/Source/Hugo/static/css/dolittle.dot.css
@@ -44,6 +44,15 @@ h1.page_title {
     padding: 0.5rem 0.5rem 0.5rem 1.75rem;
 }
 
+.list-styled span {
+    color: var(--text-color-dark);
+    cursor: pointer;
+    display: block;
+    font-weight: 400;
+    font-size: inherit;
+    padding: 0.5rem 0.5rem 0.5rem 1.75rem;
+}
+
 .list-styled a:hover {
     text-decoration: underline;
 }

--- a/Source/Hugo/static/js/dolittle.js
+++ b/Source/Hugo/static/js/dolittle.js
@@ -10,7 +10,7 @@
     addAnchorTags();
 
     //left menu expand/collapse
-    $('.list-styled .expand').on('click', function() {
+    $('.list-styled .expand, .list-styled .expand + span').on('click', function() {
         $parent = $(this).parent();
         console.log($parent);
         $parent.toggleClass('active');


### PR DESCRIPTION
Change behaviour of the navigation for sections without content.
 - If Section has no content, but has children - render navigation node without link and make clickable (expand / collapse)
 - if Section has no children and no content - hide it from the navigation list