### PR TITLE
Edit on GitHub

### DIFF
--- a/Documentation/Features/_index.md
+++ b/Documentation/Features/_index.md
@@ -1,0 +1,5 @@
+---
+title: Features
+description: Features and functionality available on the Documentation platform
+keywords: features, functionality
+---

--- a/Documentation/Features/edit_on_github.md
+++ b/Documentation/Features/edit_on_github.md
@@ -1,0 +1,31 @@
+---
+title: Edit on Github 
+description: Learn about how sub-folders can be used to structure the documentation from other repositories
+keywords: Contributing
+---
+
+A practical feature is the ability to go directly from a page in the documentation and make changes on GitHub. Doing so requires the linked repository to have the repository url defined in its base `_index.md`.
+
+## How to enable "Edit on Github" for your repository
+
+To enable support for "Edit on Github" button on a page, the top level `_index.md` in that repositories `Documentation`-folder needs to have a reference to the repository in the front matter.
+
+{{% notice note %}}
+Do not include a trailing slash at the end of the repository URL.
+{{% /notice %}}
+
+An example of front-matter with repository set:
+```markdown
+---
+...
+...
+repository: https://github.com/dolittle/Documentation
+---
+
+```
+
+All sub-articles will use this repository as the base for the links generated to edit files on GitHub.
+
+## If no repository is defined
+
+If there isn't a `repository` front matter defined no edit-button will be shown.

--- a/Documentation/_index.md
+++ b/Documentation/_index.md
@@ -4,6 +4,7 @@ description: Learn about how to contribute to documentation
 keywords: Contributing
 author: einari
 weight: 5
+repository: https://github.com/dolittle/Documentation
 ---
 
 ## Process

--- a/Source/Hugo/layouts/_default/list.html
+++ b/Source/Hugo/layouts/_default/list.html
@@ -35,6 +35,7 @@
             </div>
             <div class="col-lg-9">
                 <div class="p-5 bg-white doc_content">
+                    {{- partial "edit_on_github.html" (dict "ctx" $rootSpace "CurrentURL" .URL "CurrentPage" .Page) -}}    
                     <h1 class="page_title">{{ .Title }}</h1>
                     {{ .Content }}
                 </div>

--- a/Source/Hugo/layouts/_default/single.html
+++ b/Source/Hugo/layouts/_default/single.html
@@ -30,18 +30,19 @@
     <div class="row reverse_on_sm_and_below">
       <div class="col-lg-3">
         <div class="p-4 bg-white sticky-top">
-            {{- $rootSpace := .GetPage .Section -}}
-            {{- partial "list_navigation.html" (dict "root" $rootSpace "CurrentURL" .URL) -}}
-          </div>
+          {{- $rootSpace := .GetPage .Section -}}
+          {{- partial "list_navigation.html" (dict "root" $rootSpace "CurrentURL" .URL) -}}
+        </div>
       </div>
       <div class="col-lg-9">
         <div class="p-5 bg-white doc_content">
-            <h1 class="page_title">{{ .Title }}</h1>
+          {{- partial "edit_on_github.html" (dict "ctx" $rootSpace "CurrentURL" .URL "CurrentPage" .) -}}    
+          <h1 class="page_title">{{ .Title }}</h1>
             {{ .Content }}
             {{- if ne (string .PublishDate) "0001-01-01 00:00:00 +0000 UTC" -}}
             <p class="post-meta border-bottom pb-3 mb-0">Updated on {{ .PublishDate }}</p>
             {{- end -}}
-            {{- $currentNode := . -}}
+            {{- $currentNode := . -}}            
             <nav class="pagination mt-3">
             {{- template "pagination" dict "menu" .Site.Home "currentnode" $currentNode "menu_exclusion" .Site.Params.menu_exclusion -}}
             {{- with ($.Scratch.Get "prevPage") -}}

--- a/Source/Hugo/layouts/partials/edit_on_github.html
+++ b/Source/Hugo/layouts/partials/edit_on_github.html
@@ -37,7 +37,7 @@
         {{- $canEdit :=cond (ne $repositoryUrl nil) true false -}}
         {{- $editLink := printf "%s/edit/master/Documentation%s" $repositoryUrl $relativePath }}
         {{- if $canEdit -}}
-            <a class="edit-link" href="{{ $editLink }}"><i class="ti-pencil icon"></i></a>
+            <a class="edit-link" href="{{ $editLink }}" target="_blank"><i class="ti-pencil icon"></i></a>
         {{- end -}}
     {{- end -}}
 {{- end -}}

--- a/Source/Hugo/layouts/partials/edit_on_github.html
+++ b/Source/Hugo/layouts/partials/edit_on_github.html
@@ -37,7 +37,7 @@
         {{- $canEdit :=cond (ne $repositoryUrl nil) true false -}}
         {{- $editLink := printf "%s/edit/master/Documentation%s" $repositoryUrl $relativePath }}
         {{- if $canEdit -}}
-            <a class="btn btn-primary" href="{{ $editLink }}">Edit on Github</a>
+            <a class="edit-link" href="{{ $editLink }}"><i class="ti-pencil icon"></i></a>
         {{- end -}}
     {{- end -}}
 {{- end -}}

--- a/Source/Hugo/layouts/partials/edit_on_github.html
+++ b/Source/Hugo/layouts/partials/edit_on_github.html
@@ -19,38 +19,25 @@
     {{- if isset $currentContext.Params "repository" -}}
         {{- $currentScratch.Set "repo" ($currentContext.Param "repository") -}}
         {{- $currentScratch.Set "repoRoot" (path.Dir $currentContext.File.Path) -}}
-        <br>Repository: {{ printf "%#v" ($currentScratch.Get "repo") }}    
-        <br>RepositoryPath: {{ printf "%#v" ($currentScratch.Get "repoRoot") }}    
     {{- end -}}
     
-    <!-- {{- if $isCurrentPage -}}
-        {{- $currentScratch.Set "currentFilePath" $currentContext.File.Path -}}
-    {{- end -}} -->
-
-
-
-<br>---------------
-{{- $currentFilePath := $currentPage.File.Path -}}
-<br>File: {{ $currentFilePath }}
-<br>---------------
-{{- $repositoryUrl := ($currentScratch.Get "repo") -}}
-<br>Repo: {{ $repositoryUrl }}
-<br>---------------
-{{- $repositoryRootFilePath := ($currentScratch.Get "repoRoot") -}}
-<br>RepoRoot: {{ $repositoryRootFilePath }}
-<br>---------------
-{{- $relativePath := (strings.TrimPrefix $repositoryRootFilePath $currentFilePath) -}}
-<br>Relative Path: {{ $relativePath }}
-<br>---------------
-
-{{- $editLink := printf "%s/edit/master/Documentation%s" $repositoryUrl $relativePath }}
-<br>Github Path: {{ $editLink }}
-<br><a href="{{ $editLink }}">Edit on Github</a>
-
-<br>---------------
     {{- if $isSectionWithChildren -}}
         {{- range $pages.ByWeight -}}
             {{- partial "edit_on_github.html" (dict "ctx" . "CurrentURL" $currentURL "CurrentScratch" $currentScratch "CurrentPage" $currentPage) -}}    
+        {{- end -}}
+    {{- end -}}
+    
+    {{- if $isCurrentPage -}}
+        {{- $currentFilePath := $currentPage.File.Path -}}
+        {{- $repositoryUrl := ($currentScratch.Get "repo") -}}
+        {{- $repositoryRootFilePath := ($currentScratch.Get "repoRoot") -}}
+        
+        {{- $relativePath := (strings.TrimPrefix $repositoryRootFilePath $currentFilePath) -}}
+        
+        {{- $canEdit :=cond (ne $repositoryUrl nil) true false -}}
+        {{- $editLink := printf "%s/edit/master/Documentation%s" $repositoryUrl $relativePath }}
+        {{- if $canEdit -}}
+            <a class="btn btn-primary" href="{{ $editLink }}">Edit on Github</a>
         {{- end -}}
     {{- end -}}
 {{- end -}}

--- a/Source/Hugo/layouts/partials/edit_on_github.html
+++ b/Source/Hugo/layouts/partials/edit_on_github.html
@@ -1,0 +1,57 @@
+{{- $currentURL := .CurrentURL -}}
+{{- $currentContext := .ctx -}}
+{{- $currentScratch := cond (isset . "CurrentScratch") .CurrentScratch newScratch -}}
+{{- $currentPage := .CurrentPage -}}
+
+{{- $pages :=  (union $currentContext.Pages $currentContext.Sections) -}}
+{{- $isCurrentPage := eq (string $currentURL) $currentContext.URL -}}
+{{- $isSection := eq $currentContext.Kind "section" -}}
+{{- $isSectionWithChildren := and (eq $currentContext.Kind "section") (gt (len $pages ) 0) }}
+
+{{- $pageSlug := $currentContext.File -}}
+{{- if $isSection -}}
+{{- $pageSlug = cond (gt (len $currentContext.Dir) 0) $currentContext.Dir .Page.Title -}}
+{{- end -}}
+
+{{- $isActivePath := in (string $currentURL) (lower $pageSlug) -}}
+
+{{- if $isActivePath -}}
+    {{- if isset $currentContext.Params "repository" -}}
+        {{- $currentScratch.Set "repo" ($currentContext.Param "repository") -}}
+        {{- $currentScratch.Set "repoRoot" (path.Dir $currentContext.File.Path) -}}
+        <br>Repository: {{ printf "%#v" ($currentScratch.Get "repo") }}    
+        <br>RepositoryPath: {{ printf "%#v" ($currentScratch.Get "repoRoot") }}    
+    {{- end -}}
+    
+    <!-- {{- if $isCurrentPage -}}
+        {{- $currentScratch.Set "currentFilePath" $currentContext.File.Path -}}
+    {{- end -}} -->
+
+    <!-- {{- if $isSectionWithChildren -}} -->
+        <!-- {{- range $pages.ByWeight -}} -->
+            <!-- {{- partial "edit_on_github.html" (dict "ctx" . "CurrentURL" $currentURL "CurrentScratch" $currentScratch "CurrentPage" $currentPage) -}}     -->
+        <!-- {{- end -}} -->
+    <!-- {{- end -}} -->
+
+
+<br>---------------
+{{- $currentFilePath := $currentPage.File.Path -}}
+<br>File: {{ $currentFilePath }}
+<br>---------------
+{{- $repositoryUrl := ($currentScratch.Get "repo") -}}
+<br>Repo: {{ $repositoryUrl }}
+<br>---------------
+{{- $repositoryRootFilePath := ($currentScratch.Get "repoRoot") -}}
+<br>RepoRoot: {{ $repositoryRootFilePath }}
+<br>---------------
+{{- $relativePath := (strings.TrimPrefix $repositoryRootFilePath $currentFilePath) -}}
+<br>Relative Path: {{ $relativePath }}
+<br>---------------
+
+{{- $editLink := printf "%s/edit/master/Documentation%s" $repositoryUrl $relativePath }}
+<br>Github Path: {{ $editLink }}
+<br><a href="{{ $editLink }}">Edit on Github</a>
+
+<br>---------------
+{{- end -}}
+

--- a/Source/Hugo/layouts/partials/edit_on_github.html
+++ b/Source/Hugo/layouts/partials/edit_on_github.html
@@ -27,11 +27,6 @@
         {{- $currentScratch.Set "currentFilePath" $currentContext.File.Path -}}
     {{- end -}} -->
 
-    <!-- {{- if $isSectionWithChildren -}} -->
-        <!-- {{- range $pages.ByWeight -}} -->
-            <!-- {{- partial "edit_on_github.html" (dict "ctx" . "CurrentURL" $currentURL "CurrentScratch" $currentScratch "CurrentPage" $currentPage) -}}     -->
-        <!-- {{- end -}} -->
-    <!-- {{- end -}} -->
 
 
 <br>---------------
@@ -53,5 +48,10 @@
 <br><a href="{{ $editLink }}">Edit on Github</a>
 
 <br>---------------
+    {{- if $isSectionWithChildren -}}
+        {{- range $pages.ByWeight -}}
+            {{- partial "edit_on_github.html" (dict "ctx" . "CurrentURL" $currentURL "CurrentScratch" $currentScratch "CurrentPage" $currentPage) -}}    
+        {{- end -}}
+    {{- end -}}
 {{- end -}}
 

--- a/Source/Hugo/layouts/partials/edit_on_github.html
+++ b/Source/Hugo/layouts/partials/edit_on_github.html
@@ -1,8 +1,8 @@
-{{- $currentURL := .CurrentURL -}}
 {{- $currentContext := .ctx -}}
-{{- $currentScratch := cond (isset . "CurrentScratch") .CurrentScratch newScratch -}}
+{{- $currentURL := .CurrentURL -}}
 {{- $currentPage := .CurrentPage -}}
 
+{{- $currentScratch := cond (isset . "CurrentScratch") .CurrentScratch newScratch -}}
 {{- $pages :=  (union $currentContext.Pages $currentContext.Sections) -}}
 {{- $isCurrentPage := eq (string $currentURL) $currentContext.URL -}}
 {{- $isSection := eq $currentContext.Kind "section" -}}
@@ -10,15 +10,17 @@
 
 {{- $pageSlug := $currentContext.File -}}
 {{- if $isSection -}}
-{{- $pageSlug = cond (gt (len $currentContext.Dir) 0) $currentContext.Dir .Page.Title -}}
+    {{- $pageSlug = cond (gt (len $currentContext.Dir) 0) $currentContext.Dir .Page.Title -}}
 {{- end -}}
 
 {{- $isActivePath := in (string $currentURL) (lower $pageSlug) -}}
 
 {{- if $isActivePath -}}
-    {{- if isset $currentContext.Params "repository" -}}
-        {{- $currentScratch.Set "repo" ($currentContext.Param "repository") -}}
-        {{- $currentScratch.Set "repoRoot" (path.Dir $currentContext.File.Path) -}}
+
+    {{- $hasRepositoryDefinition := isset $currentContext.Params "repository" -}}
+    {{- if $hasRepositoryDefinition -}}
+        {{- $currentScratch.Set "repositoryUrl" ($currentContext.Param "repository") -}}
+        {{- $currentScratch.Set "repositoryRootFilePath" (path.Dir $currentContext.File.Path) -}}
     {{- end -}}
     
     {{- if $isSectionWithChildren -}}
@@ -29,14 +31,15 @@
     
     {{- if $isCurrentPage -}}
         {{- $currentFilePath := $currentPage.File.Path -}}
-        {{- $repositoryUrl := ($currentScratch.Get "repo") -}}
-        {{- $repositoryRootFilePath := ($currentScratch.Get "repoRoot") -}}
+        {{- $repositoryUrl := ($currentScratch.Get "repositoryUrl") -}}
+        {{- $repositoryRootFilePath := ($currentScratch.Get "repositoryRootFilePath") -}}
         
         {{- $relativePath := (strings.TrimPrefix $repositoryRootFilePath $currentFilePath) -}}
         
-        {{- $canEdit :=cond (ne $repositoryUrl nil) true false -}}
-        {{- $editLink := printf "%s/edit/master/Documentation%s" $repositoryUrl $relativePath }}
+        {{- $hasFoundRepositoryUrl := ne $repositoryUrl nil -}}
+        {{- $canEdit := $hasFoundRepositoryUrl -}}
         {{- if $canEdit -}}
+            {{- $editLink := printf "%s/edit/master/Documentation%s" $repositoryUrl $relativePath }}
             <a class="edit-link" href="{{ $editLink }}" target="_blank"><i class="ti-pencil icon"></i></a>
         {{- end -}}
     {{- end -}}

--- a/Source/Hugo/static/css/dolittle.dot.css
+++ b/Source/Hugo/static/css/dolittle.dot.css
@@ -192,3 +192,13 @@ h1.page_title {
         flex-direction: column-reverse;
     }
 }
+
+.edit-link {
+    position: absolute;
+    top: 50px;
+    right: 66px; 
+}
+
+.edit-link .icon {
+    font-size: 28px;
+}


### PR DESCRIPTION
A simplistic solution that resolves #34. 

It requires a manual step that involves adding the repository base url to the base `_index.md`file located in the repositories `Documentation` folder.

Added docs explaining the process