### PR TITLE
Add dolittle-tools/TypeScript.Build repo

### DIFF
--- a/Source/repositories.json
+++ b/Source/repositories.json
@@ -63,6 +63,10 @@
         "name": "tooling-platform",
         "path": "tooling"
     },
+    "https://github.com/dolittle-tools/TypeScript.Build.git": {
+        "name": "typescript-build-pipeline",
+        "path": "tooling"
+    },
     "https://github.com/dolittle-boilerplates/home.git": {
         "name": "boilerplates",
         "path": "tooling"


### PR DESCRIPTION
Working on the Documentaiton for dolittle-tools/TypeScript.Build

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1115616103797671/1143652127491812)
