### PR TITLE
Restructuring documentation

### DIFF
--- a/Source/config.toml
+++ b/Source/config.toml
@@ -81,45 +81,35 @@ home = [ "HTML", "RSS", "JSON"]
   logo = "Dolittle"
   copyright = "The Hugo Documents are copyright © gethugothemes 2018."
 
-    # # navigation
-    # [menu]
+    # navigation
+    [menu]
     
-    #   [[menu.main]]
-    #     weight = 2
-    #     name = "Faq"
-    #     url = "/faq"
+      [[menu.main]]
+        weight = 1
+        name = "Get started"
+        url = "/getting-started/tutorial/setup/"
         
-      # [[menu.main]]
-      #   weight = 2
-      #   name = "contact"
-      #   url = "/contact"
+      [[menu.main]]
+        weight = 2
+        name = "Overview"
+        url = "/getting-started/overview/"
+
+      [[menu.main]]
+        weight = 3
+        name = "Building blocks"
+        url = "/building-blocks/"
+
+      [[menu.main]]
+        weight = 4
+        name = "Platform"
+        url = "/platform/"
+
+      [[menu.main]]
+        weight = 5
+        name = "Build tools"
+        url = "/tooling/"
         
-    #   [[menu.main]]
-    #     weight = 2
-    #     name = "pages"
-    #     url = "/pages"
-    #     hasChildren = true
-
-    #       [[menu.main]]
-    #       parent = "pages"
-    #       name = "Elements"
-    #       URL = "/elements"
-    #       weight = 1
-
-    #       [[menu.main]]
-    #       parent = "pages"
-    #       name = "Installation"
-    #       URL = "/installation"
-    #       weight = 2
-
-    #       [[menu.main]]
-    #       parent = "pages"
-    #       name = "Billing and Pricing"
-    #       URL = "/billing-pricing"
-    #       weight = 3
-
-    #       [[menu.main]]
-    #       parent = "pages"
-    #       name = "Features"
-    #       URL = "/features"
-    #       weight = 4
+      [[menu.main]]
+        weight = 6
+        name = "Contribute"
+        url = "/contributing/"

--- a/Source/content/building-blocks/_index.md
+++ b/Source/content/building-blocks/_index.md
@@ -1,11 +1,11 @@
 ---
-title: Runtime
-description: The runtime and its SDKs
+title: Building blocks
+description: The essential building blocks of the Dolittle framework
 author: Dolittle
-keywords: runtime, sdk
+keywords: runtime, sdk, fundamentals, concepts, building, block, essentials
 weight: 20
 type: "space"
-icon: "ti-exchange-vertical"
+icon: "ti-package"
 ---
 
 The Dolittle [runtime](https://github.com/dolittle-runtime/Runtime) provides you with: [Commands]({{< ref about_commands >}}), [Events]({{< ref domain_events >}}), [ReadModels]({{< ref read_model >}}), [Events]({{< ref query >}}), [metrics]({{< ref metrics >}}), [tenancy]({{< ref tenancy_system >}}) and [resource management]({{< ref resources >}}) systems to build web apps.

--- a/Source/content/building-blocks/_index.md
+++ b/Source/content/building-blocks/_index.md
@@ -1,11 +1,1 @@
----
-title: Building blocks
-description: The essential building blocks of the Dolittle framework
-author: Dolittle
-keywords: runtime, sdk, fundamentals, concepts, building, block, essentials
-weight: 20
-type: "space"
-icon: "ti-package"
----
-
-The Dolittle [runtime](https://github.com/dolittle-runtime/Runtime) provides you with: [Commands]({{< ref about_commands >}}), [Events]({{< ref domain_events >}}), [ReadModels]({{< ref read_model >}}), [Events]({{< ref query >}}), [metrics]({{< ref metrics >}}), [tenancy]({{< ref tenancy_system >}}) and [resource management]({{< ref resources >}}) systems to build web apps.
+../../repositories/runtime/Runtime/Documentation/_index.md

--- a/Source/content/building-blocks/artifacts.md
+++ b/Source/content/building-blocks/artifacts.md
@@ -1,0 +1,1 @@
+../../repositories/runtime/Runtime/Documentation/artifacts.md

--- a/Source/content/building-blocks/command
+++ b/Source/content/building-blocks/command
@@ -1,0 +1,1 @@
+../../repositories/runtime/Runtime/Documentation/command

--- a/Source/content/building-blocks/domain_driven_design
+++ b/Source/content/building-blocks/domain_driven_design
@@ -1,0 +1,1 @@
+../../repositories/runtime/Runtime/Documentation/domain_driven_design

--- a/Source/content/building-blocks/dotnet-sdk
+++ b/Source/content/building-blocks/dotnet-sdk
@@ -1,0 +1,1 @@
+../../repositories/runtime/DotNET.SDK/Documentation

--- a/Source/content/building-blocks/event_horizon
+++ b/Source/content/building-blocks/event_horizon
@@ -1,0 +1,1 @@
+../../repositories/runtime/Runtime/Documentation/event_horizon

--- a/Source/content/building-blocks/events
+++ b/Source/content/building-blocks/events
@@ -1,0 +1,1 @@
+../../repositories/runtime/Runtime/Documentation/events

--- a/Source/content/building-blocks/frontend/_index.md
+++ b/Source/content/building-blocks/frontend/_index.md
@@ -1,0 +1,6 @@
+---
+title: Frontend
+author: joel
+weight: 90
+---
+

--- a/Source/content/building-blocks/frontend/aspnetcore/aspnetcore-debugging-swagger
+++ b/Source/content/building-blocks/frontend/aspnetcore/aspnetcore-debugging-swagger
@@ -1,0 +1,1 @@
+../../../../repositories/interaction/AspNetCore.Debugging.Swagger/Documentation

--- a/Source/content/building-blocks/frontend/aurelia/aurelia-client
+++ b/Source/content/building-blocks/frontend/aurelia/aurelia-client
@@ -1,0 +1,1 @@
+../../../../repositories/interaction/JavaScript.Client.Aurelia/Documentation

--- a/Source/content/building-blocks/frontend/aurelia/aurelia-components
+++ b/Source/content/building-blocks/frontend/aurelia/aurelia-components
@@ -1,0 +1,1 @@
+../../../../repositories/interaction/JavaScript.Components.Aurelia/Documentation

--- a/Source/content/building-blocks/frontend/aurelia/aurelia-contrib
+++ b/Source/content/building-blocks/frontend/aurelia/aurelia-contrib
@@ -1,0 +1,1 @@
+../../../../repositories/interaction/JavaScript.Client.Aurelia.Contrib/Documentation

--- a/Source/content/building-blocks/frontend/javascript-fundamentals
+++ b/Source/content/building-blocks/frontend/javascript-fundamentals
@@ -1,0 +1,1 @@
+../../../repositories/fundamentals/JavaScript.Fundamentals/Documentation

--- a/Source/content/building-blocks/frontend/styles
+++ b/Source/content/building-blocks/frontend/styles
@@ -1,0 +1,1 @@
+../../../repositories/interaction/Styles/Documentation

--- a/Source/content/building-blocks/frontend/webassembly
+++ b/Source/content/building-blocks/frontend/webassembly
@@ -1,0 +1,1 @@
+../../../repositories/interaction/WebAssembly/Documentation

--- a/Source/content/building-blocks/fundamentals/dotnet-fundamentals
+++ b/Source/content/building-blocks/fundamentals/dotnet-fundamentals
@@ -1,0 +1,1 @@
+../../../repositories/fundamentals/DotNET.Fundamentals/Documentation

--- a/Source/content/building-blocks/images
+++ b/Source/content/building-blocks/images
@@ -1,0 +1,1 @@
+../../repositories/runtime/Runtime/Documentation/images

--- a/Source/content/building-blocks/metrics
+++ b/Source/content/building-blocks/metrics
@@ -1,0 +1,1 @@
+../../repositories/runtime/Runtime/Documentation/metrics

--- a/Source/content/building-blocks/pipeline.md
+++ b/Source/content/building-blocks/pipeline.md
@@ -1,0 +1,1 @@
+../../repositories/runtime/Runtime/Documentation/pipeline.md

--- a/Source/content/building-blocks/principles
+++ b/Source/content/building-blocks/principles
@@ -1,0 +1,1 @@
+../../repositories/runtime/Runtime/Documentation/principles

--- a/Source/content/building-blocks/querying_for_data.md
+++ b/Source/content/building-blocks/querying_for_data.md
@@ -1,0 +1,1 @@
+../../repositories/runtime/Runtime/Documentation/querying_for_data.md

--- a/Source/content/building-blocks/read
+++ b/Source/content/building-blocks/read
@@ -1,0 +1,1 @@
+../../repositories/runtime/Runtime/Documentation/read

--- a/Source/content/building-blocks/resources
+++ b/Source/content/building-blocks/resources
@@ -1,0 +1,1 @@
+../../repositories/runtime/Runtime/Documentation/resources

--- a/Source/content/building-blocks/runtime/dotnet-sdk
+++ b/Source/content/building-blocks/runtime/dotnet-sdk
@@ -1,0 +1,1 @@
+../../../repositories/runtime/DotNET.SDK/Documentation

--- a/Source/content/building-blocks/runtime/dotnet-sdk
+++ b/Source/content/building-blocks/runtime/dotnet-sdk
@@ -1,1 +1,0 @@
-../../../repositories/runtime/DotNET.SDK/Documentation

--- a/Source/content/building-blocks/runtime/runtime
+++ b/Source/content/building-blocks/runtime/runtime
@@ -1,1 +1,0 @@
-../../../repositories/runtime/Runtime/Documentation

--- a/Source/content/building-blocks/runtime/runtime
+++ b/Source/content/building-blocks/runtime/runtime
@@ -1,0 +1,1 @@
+../../../repositories/runtime/Runtime/Documentation

--- a/Source/content/building-blocks/tenancy
+++ b/Source/content/building-blocks/tenancy
@@ -1,0 +1,1 @@
+../../repositories/runtime/Runtime/Documentation/tenancy

--- a/Source/content/building-blocks/tooling.md
+++ b/Source/content/building-blocks/tooling.md
@@ -1,0 +1,1 @@
+../../repositories/runtime/Runtime/Documentation/tooling.md

--- a/Source/content/contributing/_index.md
+++ b/Source/content/contributing/_index.md
@@ -1,8 +1,8 @@
 ---
 title: Contributing
-description: Contribute to the Dolittle platform
+description: Contribute to the Dolittle framework and platform
 author: Dolittle
-keywords: contribute, guidelines
+keywords: contribute, guidelines, github, git, how to contribute
 weight: 90
 type: "space"
 icon: "ti-github"

--- a/Source/content/fundamentals/_index.md
+++ b/Source/content/fundamentals/_index.md
@@ -1,9 +1,0 @@
----
-title: Fundamentals
-description: Dolittle's fundamentals and principles of software development
-author: Dolittle
-keywords: DDD, SDK, C#, node, javascript
-weight: 40
-type: "space"
-icon: "ti-pencil"
----

--- a/Source/content/fundamentals/dotnet-fundamentals
+++ b/Source/content/fundamentals/dotnet-fundamentals
@@ -1,1 +1,0 @@
-../../repositories/fundamentals/DotNET.Fundamentals/Documentation/

--- a/Source/content/fundamentals/javascript-fundamentals
+++ b/Source/content/fundamentals/javascript-fundamentals
@@ -1,1 +1,0 @@
-../../repositories/fundamentals/JavaScript.Fundamentals/Documentation/

--- a/Source/content/fundamentals/overview
+++ b/Source/content/fundamentals/overview
@@ -1,1 +1,0 @@
-../../repositories/fundamentals/Home/Documentation

--- a/Source/content/interaction/_index.md
+++ b/Source/content/interaction/_index.md
@@ -1,9 +1,0 @@
----
-title: Interaction
-description: Dolittle Interaction layers support
-author: Dolittle
-keywords: interaction, frontend, aurelia, react
-weight: 60
-type: "space"
-icon: "ti-desktop"
----

--- a/Source/content/interaction/aspnetcore/_index.md
+++ b/Source/content/interaction/aspnetcore/_index.md
@@ -1,7 +1,0 @@
----
-title: ASP.NET Core
-description: ASP.NET Core Interaction
-author: Dolittle
-keywords: aspnetcore, aspnet, interaction
-weight: 1
----

--- a/Source/content/interaction/aspnetcore/aspnetcore-debugging-swagger
+++ b/Source/content/interaction/aspnetcore/aspnetcore-debugging-swagger
@@ -1,1 +1,0 @@
-../../../repositories/interaction/AspNetCore.Debugging.Swagger/Documentation/

--- a/Source/content/interaction/aurelia/_index.md
+++ b/Source/content/interaction/aurelia/_index.md
@@ -1,7 +1,0 @@
----
-title: Aurelia
-description: Aurelia Interaction
-author: Dolittle
-keywords: interaction, frontend, aurelia
-weight: 4
----

--- a/Source/content/interaction/aurelia/aurelia-client
+++ b/Source/content/interaction/aurelia/aurelia-client
@@ -1,1 +1,0 @@
-../../../repositories/interaction/JavaScript.Client.Aurelia/Documentation

--- a/Source/content/interaction/aurelia/aurelia-components
+++ b/Source/content/interaction/aurelia/aurelia-components
@@ -1,1 +1,0 @@
-../../../repositories/interaction/JavaScript.Components.Aurelia/Documentation/

--- a/Source/content/interaction/aurelia/aurelia-contrib
+++ b/Source/content/interaction/aurelia/aurelia-contrib
@@ -1,1 +1,0 @@
-../../../repositories/interaction/JavaScript.Client.Aurelia.Contrib/Documentation

--- a/Source/content/interaction/styles
+++ b/Source/content/interaction/styles
@@ -1,1 +1,0 @@
-../../repositories/interaction/Styles/Documentation

--- a/Source/content/interaction/webassembly
+++ b/Source/content/interaction/webassembly
@@ -1,1 +1,0 @@
-../../repositories/interaction/WebAssembly/Documentation

--- a/Source/content/platform/_index.md
+++ b/Source/content/platform/_index.md
@@ -1,8 +1,8 @@
 ---
-title: Platform
-description: The core platform
+title: Dolittle Platform
+description: Dolittle hosting solution for Dolittle applications
 author: Dolittle
-keywords: platform, studio, sentry, identity, operations
+keywords: platform, studio, sentry, identity, operations, host
 weight: 50
 type: "space"
 icon: "ti-world"

--- a/Source/content/runtime/dotnet-sdk
+++ b/Source/content/runtime/dotnet-sdk
@@ -1,1 +1,0 @@
-../../repositories/runtime/DotNET.SDK/Documentation/

--- a/Source/content/runtime/overview
+++ b/Source/content/runtime/overview
@@ -1,1 +1,0 @@
-../../repositories/runtime/Home/Documentation

--- a/Source/content/runtime/runtime
+++ b/Source/content/runtime/runtime
@@ -1,1 +1,0 @@
-../../repositories/runtime/Runtime/Documentation

--- a/Source/content/tooling/_index.md
+++ b/Source/content/tooling/_index.md
@@ -1,9 +1,9 @@
 ---
-title: Tooling
-description: We have great tools!
-keywords: Tools
+title: Build tools
+description: CLI, packages and scripts used to build and publish Dolittle projects and plugins
+keywords: Tools, build, plugin, package
 author: einari, woksin
-weight: 30
+weight: 90
 icon: "ti-ruler-pencil"
 type: "space"
 aliases: /tooling


### PR DESCRIPTION
Renaming our top level content and consolidating most of the "fundamental" or "concepts of dolittle" kinda stuff into the building blocks folder.

Still a WIP, all the files need aliases to their old places etc.

Also lots of submodules need to be touched up after this too

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1164622814330309)
