### PR TITLE
Typo on platform

### DIFF
--- a/Source/content/en/docs/tutorials/_index.md
+++ b/Source/content/en/docs/tutorials/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Tutorials
-description: Tutorials for the Dolittle platoform
+description: Tutorials for the Dolittle platform
 keywords: overview, dolittle, why dolittle, what is dolittle, 
 author: Dolittle
 weight: 5


### PR DESCRIPTION
Whilst talking about Platforms and Microservices, noticed a little typo.

Viewable

https://dolittle.io/docs/tutorials/

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1199410082069804)


https://deploy-preview-81--dolittle-io.netlify.app/docs/tutorials/

VS

dolittle.io/docs/tutorials/