### PR TITLE
Simplify TypeScript getting started tutorial.

### DIFF
--- a/Source/content/en/docs/tutorials/getting_started.md
+++ b/Source/content/en/docs/tutorials/getting_started.md
@@ -52,9 +52,8 @@ Setup a TypeScript NodeJS project using your favorite package manager. For this 
 $ npm init
 $ npm -D install typescript ts-node
 $ npm install @dolittle/sdk
-$ npx tsc --init
+$ npx tsc --init --experimentalDecorators
 ```
-This tutorial makes use of experimental decorators. To enable it simply make sure you have "experimentalDecorators" set to true in your tsconfig.json.
 {{% /tab %}}
 {{< /tabs >}}
 


### PR DESCRIPTION
While setting up, I was too lazy to read beyond the commands to run - so I got an error when copying the first EventType class. It was written in the guide how to set it up properly, but with this extra flag in the command it works with less manual fiddling.