### PR TITLE
Improve navigation sidebar

### DIFF
--- a/Source/config.toml
+++ b/Source/config.toml
@@ -126,7 +126,8 @@ prism_syntax_highlighting = true
 # User interface configuration
 [params.ui]
 # Enable to show the side bar menu in its compact state.
-sidebar_menu_compact = false
+sidebar_menu_compact = true
+ul_show = 2
 #  Set to true to disable breadcrumb navigation.
 breadcrumb_disable = false
 #  Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)

--- a/Source/static/js/scroll-sidebar-active-into-view.js
+++ b/Source/static/js/scroll-sidebar-active-into-view.js
@@ -1,6 +1,14 @@
 $(function () {
-    const activeSidebarItem = $('div.td-sidebar .td-sidebar-nav-active-item')[0];
-    if (activeSidebarItem) {
-        activeSidebarItem.scrollIntoView({ block: 'center' });
-    }
+    const sidebar = $('nav.td-sidebar-nav')[0];
+
+    const canScroll = sidebar.scrollHeight > sidebar.clientHeight;
+    if (!canScroll) return;
+
+    const activeSidebarItem = $(sidebar).find('span.td-sidebar-nav-active-item')[0];
+    if (!activeSidebarItem) return;
+
+    const distanceFromTop = activeSidebarItem.offsetTop - sidebar.offsetTop;
+    const desiredScroll = distanceFromTop - sidebar.clientHeight/2;
+
+    sidebar.scrollTop = desiredScroll;
 });


### PR DESCRIPTION
Makes the navigation sidebar scroll the current selected page into view nicely. It was broken after the template changed a `div` element to a `nav`. And when I fixed that - it caused the `.scrollIntoView()` to scroll the whole page, not just the menu. These are both fixed now.